### PR TITLE
Replace .env with secrets.json

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,3 +1,0 @@
-token=
-dbUri=
-ghOauth=

--- a/.github/templates/pull_request_template.md
+++ b/.github/templates/pull_request_template.md
@@ -1,7 +1,7 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!--- Provide a general summary of your changes in the Title above. -->
 
 ## Description
-<!--- Describe your changes in detail -->
+<!--- Describe your changes in detail. -->
 
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
@@ -9,7 +9,7 @@
 
 ## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- Include details of your testing environment, and the tests you ran to. -->
 <!--- see how your change affects other areas of the code, etc. -->
 
 ## Screenshots (if appropriate):

--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,5 @@ dist
 
 # Environment files
 config.json
+secrets.json
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 # Instructions
 1. `npm run build` to build the bot.
-2. `npm start [configFile] [envFile]` to start the bot with the specified config.
+2. `npm start [configFile] [secretsFile]` to start the bot with the specified config.
 	- If the config file is not specified, `config.json` will be used.
-	- If the environment file is not specified, `.env` will be used.
+	- If the secrets file is not specified, `secrets.json` will be used.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"@types/node-fetch": "^2.5.10",
 		"discord-api-types": "^0.18.1",
 		"discord.js": "github:discordjs/discord.js",
-		"dotenv": "^10.0.0",
 		"exit-hook": "^2.2.1",
 		"mongoose": "^5.12.11",
 		"node-fetch": "^2.6.1",

--- a/secrets-template.json
+++ b/secrets-template.json
@@ -1,0 +1,5 @@
+{
+	"token": "",
+	"dbUri": "",
+	"ghOauth": ""
+}

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -238,7 +238,7 @@ function oauthFetch(url: string): Promise<unknown> {
 						reject(
 							oauth
 								? "Rate limit reached!"
-								: "[No Oauth] Rate limit reached! If you are seeing this error, ask the bot host to set the `ghOauth` field within the `.env` file."
+								: "[No Oauth] Rate limit reached! If you are seeing this error, ask the bot host to set the `ghOauth` field within the secrets file."
 						);
 					} else {
 						reject(res.message);

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,15 +1,15 @@
-export interface DotEnv {
+export interface Secrets {
 	readonly token: string;
 	readonly dbUri: string;
 	readonly ghOauth: string;
 }
 
-export function isDotEnv(env: unknown): env is DotEnv {
-	const record = env as { [index: string]: unknown };
+export function isSecrets(secrets: unknown): secrets is Secrets {
+	const record = secrets as { [index: string]: unknown };
 
 	return (
-		typeof env === "object" &&
-		env !== null &&
+		typeof secrets === "object" &&
+		secrets !== null &&
 		typeof record["token"] === "string" &&
 		typeof record["dbUri"] === "string" &&
 		typeof record["ghOauth"] === "string"


### PR DESCRIPTION
The values in `.env` were never loaded into the environment, and using
a JSON file is more ergonomic and requires 1 less dependency.

This is a BREAKING CHANGE, the current `.env` must be renamed to
`secrets.json` and edited to be in the JSON format.