### PR TITLE
Feature/bugs

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -1,9 +1,9 @@
 import { CommandInteraction, GuildMember, MessageEmbed } from "discord.js";
 import fetch from "node-fetch";
-import type { Command } from "../types/command";
 import { log } from "../logger";
 import { getOauth } from "../store/githubOauth";
 import { getState } from "../store/state";
+import type { Command } from "../types/command";
 import type { Branch, Commit, GithubUser, Issue, PullRequest, Repository } from "../types/github";
 
 const command: Command = {
@@ -60,6 +60,8 @@ const command: Command = {
 		const objectType = (args.get("name")?.value as string).toLowerCase();
 		const query = args.get("query")?.value as string;
 		const embedReply = new MessageEmbed();
+
+		console.log(repo);
 
 		const route =
 			objectType === "repo"

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -13,7 +13,7 @@ const event: Event = {
 		const guild = member.guild;
 
 		const config = getState().config;
-		const logChannel = (await guild.channels.fetch(config.joinLogChannelId as `${bigint}`)) as TextChannel;
+		const logChannel = (await guild.channels.fetch(config.joinLogChannelId)) as TextChannel;
 
 		const creation = member.user.createdAt;
 		const now = new Date(Date.now());

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -1,0 +1,54 @@
+import { log } from "console";
+import { GuildMember, MessageActionRow, MessageButton, TextChannel } from "discord.js";
+import { getState } from "../store/state";
+import type { Event } from "../types/event";
+import { embedCache } from "./guildMemberAdd";
+
+const event: Event = {
+	name: "guildMemberRemove",
+	execute: (...args) => {
+		log(`Firing event: ${event.name}`, "debug");
+		const newMember = [...args][0] as unknown as GuildMember;
+		const guild = newMember.guild;
+
+		const messageId = embedCache.get(newMember.id);
+		const logChannel = guild.channels.cache.get(getState().config.joinLogChannelId) as TextChannel;
+
+		if (logChannel && messageId) {
+			logChannel.messages
+				.fetch(messageId)
+				.then(message => {
+					const components = message.components[0].components;
+
+					if (components.find(component => component.customID === "kick")) {
+						message
+							.edit({
+								embeds: message.embeds,
+								components: [
+									new MessageActionRow().addComponents(
+										new MessageButton()
+											.setCustomID("left")
+											.setStyle("SUCCESS")
+											.setLabel("User Left")
+											.setDisabled(true),
+										new MessageButton()
+											.setCustomID("memberId")
+											.setStyle("SECONDARY")
+											.setLabel(newMember.id)
+											.setDisabled(true),
+										new MessageButton().setCustomID("ban").setStyle("DANGER").setLabel("Ban")
+									),
+								],
+							})
+							.then(() => {
+								embedCache.delete(newMember.id);
+							})
+							.catch(err => log(err, "error"));
+					}
+				})
+				.catch(err => log(err, "error"));
+		}
+	},
+};
+
+export default event;

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -18,10 +18,15 @@ const event: Event = {
 			}
 
 			if (JSON.parse(config.removeMemberRoleOnMute)) {
-				if (newMember.roles.cache.has(config.mutedRoleId as `${bigint}`)) {
-					newMember.roles.remove(config.memberRoleId).catch(err => log(err, "error"));
-				} else if (!newMember.roles.cache.has(config.mutedRoleId as `${bigint}`)) {
+				const mutedRoleSnowflake = config.mutedRoleId;
+
+				if (oldMember.roles.cache.has(mutedRoleSnowflake) && !newMember.roles.cache.has(mutedRoleSnowflake)) {
 					newMember.roles.add(config.memberRoleId).catch(err => log(err, "error"));
+				} else if (
+					!oldMember.roles.cache.has(mutedRoleSnowflake) &&
+					newMember.roles.cache.has(mutedRoleSnowflake)
+				) {
+					newMember.roles.remove(config.memberRoleId).catch(err => log(err, "error"));
 				}
 			}
 		}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,5 +1,6 @@
 import type { Event } from "../types/event";
 import guildMemberAdd from "./guildMemberAdd";
+import guildMemberRemove from "./guildMemberRemove";
 import guildMemberUpdate from "./guildMemberUpdate";
 import interactionCreate from "./interactionCreate";
 import messageCreate from "./messageCreate";
@@ -7,6 +8,7 @@ import ready from "./ready";
 
 const events = {
 	guildMemberAdd,
+	guildMemberRemove,
 	guildMemberUpdate,
 	interactionCreate,
 	messageCreate,

--- a/src/menus/captchaSelector.ts
+++ b/src/menus/captchaSelector.ts
@@ -23,9 +23,7 @@ export function handleCaptchaSelector(
 			})
 			.then(() => {
 				const messageId = embedCache.get(user.id);
-				const logChannel = guild?.channels.cache.get(
-					getState().config.joinLogChannelId as `${bigint}`
-				) as TextChannel;
+				const logChannel = guild?.channels.cache.get(getState().config.joinLogChannelId) as TextChannel;
 
 				if (logChannel && messageId) {
 					logChannel.messages

--- a/src/structures/config.ts
+++ b/src/structures/config.ts
@@ -13,8 +13,8 @@ export interface Config {
 	verbosityLevel: string;
 	logChannelId: Snowflake;
 	removeMemberRoleOnMute: string;
-	mutedRoleId: string;
-	joinLogChannelId: string;
+	mutedRoleId: Snowflake;
+	joinLogChannelId: Snowflake;
 }
 
 export function isConfig(config: unknown): config is Config {


### PR DESCRIPTION
## Closes #103

Serverinfo is now ephemeral in all channels except bot command channel.
Serverinfo now works for all members outside of bot command channel.

## Closes #105 

Bot now updates roles only when the mute role is involved.

## Closes #106 

Kick button now disables and updates to display "User left" if a user leaves before verifying.